### PR TITLE
Firestore doesn't like seeing null properties

### DIFF
--- a/audiotool/functions/src/estorage.ts
+++ b/audiotool/functions/src/estorage.ts
@@ -524,7 +524,7 @@ export class EUser {
     this.parent = parent;  // EStorage system
     this.path = path;  // Firebase document reference path
 
-    this.euid = fsdata.euid;  // Immutable´
+    this.euid = fsdata.euid;  // Immutable
     this.fbuid = fsdata.fbuid;  // This can be null for unclaimed accounts
     this.normalizedEmail = fsdata.normalizedEmail;
 
@@ -571,12 +571,15 @@ export class EUser {
 
   // Updates this user with any changes carried by this DAO.
   update(txn: Transaction): void {
-    txn.update(this.parent.firestore.doc(this.path), {
+    const obj: any = {
       // EUID is immutable, never update it
-      fbuid: this.fbuid,
       normalizedEmail: this.normalizedEmail,
       info: JSON.stringify(this.info)
-    });
+    };
+    if (this.fbuid) {
+      obj['fbuid'] = this.fbuid;  // Only set property keys with non-null values
+    }
+    txn.update(this.parent.firestore.doc(this.path), obj);
   }
 
   // Returns true if the user's agreements match the live versions of all applicable consents


### PR DESCRIPTION
Creating a user from the admin GUI results in this crash:

>  Error: Update() requires either a single JavaScript object or an alternating list of field/value pairs that can be followed by an optional precondition. Value for argument "dataOrField" is not a valid Firestore value. "undefined" values are only ignored in object properties.
>      at WriteBatch.update (/Users/rheywood/src/euphonia/audiotool/functions/node_modules/@google-cloud/firestore/build/src/write-batch.js:377:23)
>      at Transaction.update (/Users/rheywood/src/euphonia/audiotool/functions/node_modules/@google-cloud/firestore/build/src/transaction.js:222:26)
>      at EUser.update (/Users/rheywood/src/euphonia/audiotool/functions/src/estorage.ts:574:9)
>      at EUser.assignTasks (/Users/rheywood/src/euphonia/audiotool/functions/src/estorage.ts:750:10)
>      at processTicksAndRejections (node:internal/process/task_queues:96:5)
>      at /Users/rheywood/src/euphonia/audiotool/functions/src/estorage.ts:1017:9
>      at Transaction.runTransaction (/Users/rheywood/src/euphonia/audiotool/functions/node_modules/@google-cloud/firestore/build/src/transaction.js:322:26)
>      at ETaskSet.assignTasks (/Users/rheywood/src/euphonia/audiotool/functions/src/estorage.ts:1014:16)
>      at EStorage.createUser (/Users/rheywood/src/euphonia/audiotool/functions/src/estorage.ts:158:14)
>      at AudioApi.runAdminApiNewUser (/Users/rheywood/src/euphonia/audiotool/functions/src/audioapp.ts:369:30)
>      at Function.runMemberEndpoint (/Users/rheywood/src/euphonia/audiotool/functions/src/audioapp.ts:149:14)
>      at fn (/Users/rheywood/src/euphonia/audiotool/functions/src/audioapp.ts:112:22)
i  functions: Finished "us-central1-audioapp" in 2282.769209ms
