### PR TITLE
Add a feature to delete users

### DIFF
--- a/audiotool/README.md
+++ b/audiotool/README.md
@@ -4,7 +4,7 @@ This is a reference implementation of a web-based tool which can collect audio d
 
 ## One-Time Setup Instructions (MacBook)
 
-NOTE: To get this demo fully working for yourself, you will need to set up a Google Cloud account and project. If you already have one, you can fill in its name and credentials in the places where you see "yourproject" and "youtname" in the config files.
+NOTE: To get this demo fully working for yourself, you will need to set up a Google Cloud account and project. If you already have one, you can fill in its name and credentials in the places where you see "yourproject" and "yourname" in the config files.
 
 1. Install node: https://nodejs.org/en/download/
 2. Run the installer to completion. As of this writing I get:

--- a/audiotool/README.md
+++ b/audiotool/README.md
@@ -18,13 +18,11 @@ NOTE: To get this demo fully working for yourself, you will need to set up a Goo
 
 5. cd euphonia/audiotool
 
-6. cp ./deploy_test.json.example ./deploy_test.json 
+6. cp ./deploy_test.json.example ./deploy_local.json 
 
-7. Edit ./deploy_test.json and fill in your GCP project credentials (or get this file from an existing team member)
+7. Edit ./deploy_local.json and fill in your GCP project credentials (or get this file from an existing team member)
 
-8. cp ./deploy_test.json.example ./deploy_local.json 
-
-9. ./node_modules/.bin/firebase login
+8. ./node_modules/.bin/firebase login
 
 
 ## Run Firebase locally
@@ -35,7 +33,7 @@ NOTE: To get this demo fully working for yourself, you will need to set up a Goo
 
 ## Deploy to test
 
-1. Create a deploy_test.json file by copying the example
+1. Create a deploy_test.json file by copying and modifying the example file (deploy_test.json.example)
 2. Create a test_key.json by downloading this file from your Firebase project console (or get this file from a team member)
 3. Fill in all the required values in both files, such as project name and hosting site name
 4. ./deploy.sh
@@ -68,6 +66,10 @@ notes on compatibility based on my testing:
   - Playback feature not compatible with async methods; implemented a different playback widget on Safari
   - ScriptProcessorNode does not work unless a GainNode is added to the chain
 
-### Known issues
+### Known issues / Troubleshooting
 
 - iOS 13 + Chrome does not work. Must use Safari on old iOS devices.
+
+- If you get an error like `Error: Failed to get Firebase project`,
+  try doing "firebase logout" and then "firebase login" again
+  

--- a/audiotool/commonsrc/schema.ts
+++ b/audiotool/commonsrc/schema.ts
@@ -84,6 +84,7 @@ export interface EUserInfo {
   createTimestamp: number;
   signupTimestamp: number;
   numAssignmentsByTaskSet: Array<[taskSetId: string, numAssignments: number]>;
+  deleted?: boolean;  // Indicates that this user asked for their PII to be removed. Only the euid remains.
 }
 
 // Structured storage of interest form reply

--- a/audiotool/functions/src/audioapp.ts
+++ b/audiotool/functions/src/audioapp.ts
@@ -571,7 +571,7 @@ export class AudioApi {
   async runAdminApiRemoveTasks() {
     const info = this.getBodyJSON();
     const euid = requireParam(info.euid as string);
-    const idTuples = requireArray(info.idTuples as Array<[string, string]>, 1);  // list of [taskSetId, user taskId]
+    const idTuples = requireArray(info.idTuples as Array<[string, string]>, 1);  // list of [taskSetId, userTaskId]
     let user: EUser;
     let taskSets: ETaskSet[];
     for (const idTuplesBatch of toBatches(idTuples, 450)) {

--- a/audiotool/websrc/admin/admindata.ts
+++ b/audiotool/websrc/admin/admindata.ts
@@ -112,6 +112,15 @@ export class AdminData {
     });
   }
 
+  // Deletes an existing user
+  async deleteUser(euid: string) {
+    await this.run(['users'], async () => {
+      const info = {euid};
+      const [user] = await postAsJson('/api/admin/deleteuser', info) as [schema.EUserInfo];
+      this.users.set(user.euid, user);
+    });
+  }
+
   // Assigns a selection of tasks to a list of users, returning which euids were successful.
   async assignTasks(euids: string[], taskSetId: string, spec: schema.EAssignmentRule): Promise<string[]> {
     const rv = await this.run(['users', 'usertasks', 'tasksets'], async () => {

--- a/audiotool/websrc/admin/userdetail.ts
+++ b/audiotool/websrc/admin/userdetail.ts
@@ -53,7 +53,8 @@ export class UserDetailView {
   // Fills in the user details
   private fillUserInfo() {
     this.userinfo.empty();
-    this.userinfo.eadd('<div class=euid />').etext(`User ${this.user.euid}`);
+    const deletedText = this.user.deleted ? ' - DELETED' : '';
+    this.userinfo.eadd('<div class=euid />').etext(`User ${this.user.euid}${deletedText}`);
     const table = this.userinfo.eadd('<table />');
     table.eaddtr([$('<span class=label />').etext('Name:'), $('<span />').etext(`${this.getNameInfo()}`)]);
     table.eaddtr([$('<span class=label />').etext('Email:'), $('<span />').etext(`${this.user.email}`)]);
@@ -86,6 +87,7 @@ export class UserDetailView {
     buttons.eadd('<button />').etext('Edit User').on('click', async e => await this.startEdit());
     buttons.eadd('<button />').etext('Assign tasks').on('click', async e => await this.startAssign());
     buttons.eadd('<button />').etext('Unassign all remaining tasks').on('click', async e => await this.unassignAll());
+    buttons.eadd('<button />').etext('Delete user').on('click', async e => await this.deleteUser());
     this.parent.app.setNav(`/user/${this.user.euid}`);
   }
 
@@ -236,6 +238,19 @@ export class UserDetailView {
   // Shows the assignment dialog
   async startAssign() {
     await new BulkAssignDialog(this.parent.app, [this.user.euid]).start();
+  }
+
+  // Deletes the user and all their recordings, after confirmation
+  async deleteUser() {
+    const confirm = await ChoiceDialog.choose('Delete user and all recordings? This cannot be undone.', 'DELETE', 'Cancel');
+    if (confirm !== 'DELETE') {
+      return;
+    }
+    
+    await Spinner.waitFor(async () => {
+      await this.data.deleteUser(this.user.euid);
+    });
+    this.parent.start();
   }
 }
 

--- a/audiotool/websrc/admin/users.ts
+++ b/audiotool/websrc/admin/users.ts
@@ -154,7 +154,7 @@ export class UsersView {
     const tbody = this.table.eadd('<tbody />');
     this.ticks.clear();
     for (const user of this.toSorted(this.app.data.users)) {
-      if (!this.filterFn(user)) {
+      if (!this.filterFn(user) || user.deleted) {
         continue;
       }
       const euid = user.euid;


### PR DESCRIPTION
- Adds a "DELETE" button to the user GUI for admins
- Deletes the user's recordings and unassigns all their tasks
- Keeps the user record around so that the EUID isn't reused, but redacts the PII
- The existing removal logic is reused instead of running lower level batch deletion logic on Firestore and GCS, so that the aggregate counters on TaskSet are correctly decremented.
- Firestore's transaction feature in theory should keep the counters from going askew